### PR TITLE
Feat : Add Docker Files to Flask Microservice

### DIFF
--- a/API/app.py
+++ b/API/app.py
@@ -38,7 +38,7 @@ def initialize_models():
 
         if model is None:
             try : 
-                model = joblib.load('ML Model\model.pkl') 
+                model = joblib.load('ML Model/model.pkl')
 
             except FileNotFoundError:
                 raise Exception("Model file not found. Please check the file path.")

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Use official Python base image
+FROM python:3.10-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Copy all project files into the container
+COPY . .
+
+# Install dependencies
+RUN pip install --upgrade pip && \
+    pip install -r requirements.txt
+
+# Expose the port your Flask app runs on
+EXPOSE 8890
+
+# Default command to run the Flask app with Gunicorn
+CMD ["gunicorn", "--config", "API/gunicorn_config.py", "API.app:app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+
+services:
+  driver_behavior_api:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: driver_behavior_api
+    ports:
+      - "8890:8890"
+    volumes:
+      - .:/app
+    environment:
+      - PYTHONUNBUFFERED=1
+    restart: unless-stopped


### PR DESCRIPTION
# 🔧 Pull Request: Add Docker Support for Driver Behavior Microservice

## 🚀 Summary

This PR introduces full Docker support for containerizing and running the **driver behavior prediction microservice**. It includes:

- A `Dockerfile` for building a standalone image of the Flask application using Gunicorn.
- A `docker-compose.yaml` file to simplify local development and deployment using Docker Compose.

---

## 📝 Changes Introduced

### ✅ `Dockerfile`
- Uses the official Python base image: `python:3.10-slim`
- Copies the project files into the container’s `/app` directory
- Installs Python dependencies via `requirements.txt`
- Uses **Gunicorn** to serve the Flask app in a production environment
- Exposes application port `8890`

### ✅ `docker-compose.yaml`
- Defines a `driver_behavior_api` service
- Builds the image from the Dockerfile
- Maps host port `8890` to container port `8890`
- Mounts the current directory into the container for live code reflection
- Enables automatic container restart using `restart: unless-stopped`

---

## 📂 Project Structure Assumption

├── API/
│ ├── app.py
│ └── gunicorn_config.py
├── ML Model/
│ └── model.pkl
├── Dockerfile
├── docker-compose.yaml
├── requirements.txt

## 🧪 How to Test

1. **Build the image**:
   ```bash
   docker-compose build
   ```

2. **Run the container:**:
   ```bash
    docker-compose up
   ```

2. **Test the service:**

- Visit Swagger UI at: http://localhost:8890/apidocs/
